### PR TITLE
Pour qu'on n'ait plus de problemes avec les pycache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+imaginatiiif/imaginatiiif/__pycache__
+imaginatiiif/imaginatiiif/modeles/__pycache__


### PR DESCRIPTION
J'ai créé un fichier .gitignore à la racine pour dire à Git qu'il ne faut plus s'occuper des fichiers qui nous posent problème dans les dossiers __pycache__.